### PR TITLE
add settings frameContext to registerOnRemoveHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tslint": "^5.8.0",
     "tslint-eslint-rules": "^4.1.1",
     "typescript": "^2.5.0",
+    "uglifyjs-webpack-plugin": "^2.2.0",
     "webpack": "^4.20.2",
     "webpack-cli": "^3.1.2",
     "yargs": "^8.0.1"

--- a/src/public/settings.ts
+++ b/src/public/settings.ts
@@ -68,7 +68,7 @@ export namespace settings {
    * @param handler The handler to invoke when the user selects the remove button.
    */
   export function registerOnRemoveHandler(handler: (evt: RemoveEvent) => void): void {
-    ensureInitialized(frameContexts.remove);
+    ensureInitialized(frameContexts.settings, frameContexts.remove);
     removeHandler = handler;
     handler && sendMessageRequestToParent('registerHandler', ['remove']);
   }


### PR DESCRIPTION
We found that there is no "remove" frame context when managing connectors (unlike tabs). This is the only thing that actually worked.

Related to:

#297 
https://github.com/MicrosoftDocs/msteams-docs/issues/859
